### PR TITLE
Fix `kbd-mode--show-macros-p' call (issue #11)

### DIFF
--- a/kbd-mode.el
+++ b/kbd-mode.el
@@ -241,7 +241,7 @@ For details, see `https://github.com/kmonad/kmonad'."
   (set-syntax-table kbd-mode-syntax-table)
   (use-local-map kbd-mode-map)
   (font-lock-add-keywords 'kbd-mode kbd-mode--font-lock-keywords)
-  (kbd-mode--show-macros? kbd-mode-show-macros))
+  (kbd-mode--show-macros-p kbd-mode-show-macros))
 
 ;; HACK
 (defadvice redisplay (after refresh-font-locking activate)


### PR DESCRIPTION
Commit a4c5f1c60ff renamed `kbd-mode--show-macros?' to `kbd-mode--show-macros-p' and updated its caller.  Then, apparently accidentally, commit a7678e43c9eb reverted just the caller change. The result is that when the `kbd-mode' is invoked, say by finding a .kbd file into a buffer, one gets the following error:

    File mode specification error: (void-function kbd-mode--show-macros?)

This commit just changes the caller use the new name again.