### PR TITLE
Fix compile warning about font-lock-fontify-buffer

### DIFF
--- a/kbd-mode.el
+++ b/kbd-mode.el
@@ -3,7 +3,7 @@
 ;; Copyright 2020–2025  Tony Zorman
 ;; URL: https://github.com/kmonad/kbd-mode
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "24.4"))
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -268,7 +268,7 @@ For details, see `https://github.com/kmonad/kmonad'."
 This accommodates for example double quotes which are keycodes in
 KMonad."
   (when (derived-mode-p 'kbd-mode)
-    (font-lock-fontify-buffer)))
+    (font-lock-ensure)))
 
 ;; Associate the `.kbd' ending with `kbd-mode'.
 ;;;###autoload


### PR DESCRIPTION
I get this warning every time I start Emacs:

    Warning (bytecomp): ‘font-lock-fontify-buffer’ is for interactive use only; use ‘font-lock-ensure’ or ‘font-lock-flush’ instead.

Thus this fix.  And then we bump Emacs minimum version to 25.1, because package-lint tells me that is required to use `font-lock-ensure`.